### PR TITLE
FIX hide decimals

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -89,18 +89,31 @@ function pclct_format_cost($cost) {
 		$cost = str_replace(" per ", "/", $cost);
 	}
 	
-	if(pmpro_getOption('pmpro_hide_decimals') == 'Yes'){
+	if ( pmpro_getOption( 'pmpro_hide_decimals' ) == 'Yes' ) {
+
+		// Default currency decimal separator
+		$decimal_separator = '.';
+
+		// Default currency decimals
+		$decimals = 2;
+
 		if ( ! empty( $pmpro_currency )
-		&& is_array( $pmpro_currencies[$pmpro_currency] )
-		&& isset( $pmpro_currencies[$pmpro_currency]['decimal_separator'] ) ) {
-			$decimal_separator = $pmpro_currencies[$pmpro_currency]['decimal_separator'];
-		} else {
-			$decimal_separator = '.';
+		&& is_array( $pmpro_currencies[ $pmpro_currency ] ) ) {
+			// Get currency decimal separator
+			if ( isset( $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] )
+			&& $pmpro_currencies[ $pmpro_currency ]['decimal_separator'] !== $decimal_separator ) {
+				$decimal_separator = $pmpro_currencies[ $pmpro_currency ]['decimal_separator'];
+			}
+			// Get currency decimals
+			if ( isset( $pmpro_currencies[ $pmpro_currency ]['decimals'] )
+			&& $pmpro_currencies[ $pmpro_currency ]['decimals'] !== $decimals ) {
+				$decimals = $pmpro_currencies[ $pmpro_currency ]['decimals'];
+			}
 		}
-		
-		$parts = explode( $decimal_separator, $cost );
-		if ( ! empty( $parts[1] ) && $parts[1] == 0 ) {
-			$cost = $parts[0];
+
+		// Replace trailing zeroes only if currency has trailing decimals
+		if ( $decimals > 0 ) {
+			$cost = str_replace( $decimal_separator . str_repeat( '0', $decimals ), '', $cost );
 		}
 	}
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fix breaking of cost text if multiple occurrences of currency amounts appear in `$cost` string value.

Resolves https://github.com/strangerstudios/pmpro-subscription-delays/issues/25

### How to test the changes in this Pull Request:

1. In a new WordPress installation with Memberlite theme active add and activate PMPro Core and [Sub Delays Add On](https://github.com/strangerstudios/pmpro-subscription-delays)
2. Create Test Level "Sub Delay level one" with `0` Initial Payment, check Recurring Subscription, set Billing Amount to `100` per `1` `Year(s). Set Subscription delay to `7`.
3. Create Test Level "Sub Delay level two" with `200` Initial Payment, check Recurring Subscription, set Billing Amount to `300.5` per `1` `Month(s). Set Subscription delay to `2022-01-23`
4. Navigate Membership Levels page to observe level cost text: 
	4.1 Sub Delay level one: $0.00 now and then $100.00 per Year after your 7 day trial. 
	4.2 Sub Delay level two: $200.00 now and then $300.50 per Month starting January 23, 2022. 
5. Install and activate Custom Level Cost Text Add On.
6. Navigate to Memberships > Settings > Advanced and set the Hide Unnecessary Decimals option for Level Cost Text Settings to `Yes` and save settings.
7. Navigate to the Membership Levels page on the frontend and observe level cost text
	7.1 Sub Delay level one: $0
	7.2 Sub Delay level two: $200
8. Replace [pmpro_hide_decimals](https://github.com/strangerstudios/pmpro-level-cost-text/blob/22c3ba4611ad4b3a3bf4af0bdee7ef3c916ffd87/pmpro-level-cost-text.php#L92-L105) code with this patch
9. Navigate to the Membership Levels page on the frontend and observe level cost text
	9.1 Sub Delay level one: $0 now and then $100 per Year after your 7 day trial. 
	9.2 Sub Delay level two: $200 now and then $300.50 per Month starting January 23, 2022. 

<details>
<summary>Screenshots</summary>

**Default Level Cost Text**
![211201-1638335933](https://user-images.githubusercontent.com/9744519/144182657-1489d6a3-55b7-4f57-80ec-e6bf7ef4eaac.png)

---
**Level Cost Text before the patch**
![211201-1638336086](https://user-images.githubusercontent.com/9744519/144182750-3af31b40-63fc-46fc-88ba-daa54064f5cc.png)

---
**Level Cost Text after the patch**
![211201-1638336365](https://user-images.githubusercontent.com/9744519/144182831-4e369006-ef71-43e5-a347-947e5f22f18c.png)

---
**Level Cost Text after the patch - all PCLCT settings enabled**
![211201-1638339889](https://user-images.githubusercontent.com/9744519/144183452-efd4aaed-0bd7-4ba3-b79c-4b1237ed54f0.png)

---

</details>


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> BUG FIX: Fix breaking of cost text if multiple occurrences of currency amounts appear in $cost string value.