### PR TITLE
Adjustments to Hide Decimal Setting Logic

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -100,7 +100,7 @@ function pclct_format_cost($cost) {
 		
 		$parts = explode( $decimal_separator, $cost );
 		if ( ! empty( $parts[1] ) && strpos( $parts[1], '00' ) !== false ) {
-			$cost = str_replace( '.00', '', $cost );
+			$cost = str_replace( $decimal_separator . '00 ', ' ' , $cost ); //Add a space here to ensure we're getting the decimal place.
 		}
 	}
 	

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -99,7 +99,7 @@ function pclct_format_cost($cost) {
 		}
 		
 		$parts = explode( $decimal_separator, $cost );
-		if ( ! empty( $parts[1] ) && $parts[1] == 0 ) {
+		if ( ! empty( $parts[1] ) && strpos( $parts[1], '00' ) !== false ) {
 			$cost = $parts[0];
 		}
 	}

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -100,7 +100,7 @@ function pclct_format_cost($cost) {
 		
 		$parts = explode( $decimal_separator, $cost );
 		if ( ! empty( $parts[1] ) && strpos( $parts[1], '00' ) !== false ) {
-			$cost = $parts[0];
+			$cost = str_replace( '.00', '', $cost );
 		}
 	}
 	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adjusted logic that handles the 'Hide Decimals' setting. 

We current check if the second part of the string is '0' but most seem to be '00' and additional level cost text such as 'now' etc

![cost-text-string-0](https://user-images.githubusercontent.com/8989542/211301327-ace60408-f263-41f2-88a9-bd1fc6f48a57.PNG)

With the setting enabled, the decimals remain:

![cost-text-string-1](https://user-images.githubusercontent.com/8989542/211301382-c6dcda90-5f51-4adf-bef4-ec1ec62ee15e.PNG)

After these changes applied:

![cost-text-string-2](https://user-images.githubusercontent.com/8989542/211301419-1ae3d172-c002-4ddc-aac1-96429f205465.PNG)

Resolves #25
Resolves #18 
Resolves #13 

### How to test the changes in this Pull Request:

1. Navigate to Advanced Settings
2. Set the 'Hide Unnecessary Decimals' setting to 'yes'
3. Prices should show as $49 etc

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Adjustments made to the Hide Decimals setting