### PR TITLE
Uncaught error for array_merge

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -411,7 +411,7 @@ function plct_add_action_links($links) {
 		$new_links = array(
 			'<a href="' . admin_url('admin.php?page=pmpro-advancedsettings#LevelCostText') . '" title="' . esc_attr(__('Go to Level Cost Text Advanced Settings', 'pmpro-level-cost-text')) . '">' . __('Settings', 'pmpro-level-cost-text') . '</a>',
 		);
-		$links = array_merge( $new_links, $links );
+		$links = array_merge( $links, $new_links );
 	}
 	return $links;
 }


### PR DESCRIPTION
This error only seems to come up on some installs and 'technically' there isn't anything in the code that is out of the ordinary to other parts where we use array_merge

However, on line 414 we merge the current $links into the $new_links while in other places we do it the other way around

My thinking is that we need to merge $new_links into $links as it might be null in some instances, so doing it backwards causes an issue (because null is then going into $new_links instead). 

This should resolve: 

Resolves #26
Resolves #15