### PR TITLE
Removes expiration text when using custom level cost text

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -248,14 +248,30 @@ function pclct_pmpro_level_cost_text_levels($cost, $level)
 	if(!empty($custom_text))
 	{
 		$cost = pclct_apply_variables($custom_text, $cost, $level);
+		//Removes expiration text when using custom level text
+		add_filter( 'pmpro_levels_expiration_text', 'pclct_remove_expiration_text', 10, 2 );
 	}
 	else{
 		$cost = pclct_format_cost($cost);
-	}
+	}	
 	
 	return $cost;
 }
 add_filter("pmpro_level_cost_text", "pclct_pmpro_level_cost_text_levels", 15, 2);		//priority 15, so discount code text will override this
+
+function pclct_remove_expiration_text( $expiration_text, $levels ) {
+
+	if( empty( $levels ) ) {
+		return $expiration_text;
+	};
+	foreach( $levels as $level ) {
+		$custom_text = pmpro_getCustomLevelCostText( $level );
+		if ( ! empty( $custom_text ) ) {
+			return;
+		}
+	}
+	return $expiration_text;
+}
 
 /*	
 	This function will save a level_cost_text for a discount code into an array stored in pmpro_code_level_cost_text.

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -259,6 +259,14 @@ function pclct_pmpro_level_cost_text_levels($cost, $level)
 }
 add_filter("pmpro_level_cost_text", "pclct_pmpro_level_cost_text_levels", 15, 2);		//priority 15, so discount code text will override this
 
+/**
+ * Removes the expiration text if custom level cost text has been set.
+ * 
+ * @param $expiration_text string The current expiration text string
+ * @param $levels array The levels that the expiration text are used on
+ * 
+ * @since TBD
+ */
 function pclct_remove_expiration_text( $expiration_text, $levels ) {
 
 	if( empty( $levels ) ) {

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -269,9 +269,10 @@ add_filter("pmpro_level_cost_text", "pclct_pmpro_level_cost_text_levels", 15, 2)
  */
 function pclct_remove_expiration_text( $expiration_text, $levels ) {
 
-	if( empty( $levels ) ) {
+	if ( empty( $levels ) ) {
 		return $expiration_text;
 	};
+	
 	foreach( $levels as $level ) {
 		$custom_text = pmpro_getCustomLevelCostText( $level );
 		if ( ! empty( $custom_text ) ) {


### PR DESCRIPTION
Removes the expiration text for a level that uses custom level cost text - we assume that they add the expiration text in their new level cost text. 

Resolves #9