### PR TITLE
Fixing error where level cost text applied to discount codes wasn't saving.

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -368,7 +368,7 @@ function pclct_pmpro_save_discount_code_level( $code_id, $level_id ) {
 
 	// If we updated level cost text, save the values.
 	if ( ! empty( $all_levels_a ) ) {
-		// Find the location of  the level in the array.
+		// Find the location of the level in the array.
 		$key = array_search( $level_id, $all_levels_a );
 
 		// Add level cost text for this level.

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -356,19 +356,26 @@ function pclct_pmpro_discount_code_after_level_settings($code_id, $level)
 }
 add_action("pmpro_discount_code_after_level_settings", "pclct_pmpro_discount_code_after_level_settings", 10, 2);
 
-//save level cost text for the code when the code is saved/added
-function pclct_pmpro_save_discount_code_level($code_id, $level_id)
-{
-	$all_levels_a = array_map( 'intval', $_REQUEST['all_levels'] );							//array of level ids checked for this code
-	$level_cost_text_a = array_map( 'wp_kses_post', $_REQUEST['level_cost_text'] );			//level_cost_text for levels checked
+/**
+ * Save level cost text for a discount code when it is saved/added.
+ */
+function pclct_pmpro_save_discount_code_level( $code_id, $level_id ) {
+	// Get the array of level ids checked for this code.
+	$all_levels_a = array_map( 'intval', $_REQUEST['all_levels'] );
 
-	if(!empty($all_levels_a))
-	{
-		$key = array_search($level_id, $all_levels_a);				//which level is it in the list?
-		pmpro_saveCodeCustomLevelCostText($code_id, $level_id, wp_unslash( $level_cost_text_a[$key] ) );			//add level cost text for this level
+	// Get the level_cost_text field for levels checked.
+	$level_cost_text_a = array_map( 'wp_kses_post', $_REQUEST['level_cost_text'] );
+
+	// If we updated level cost text, save the values.
+	if ( ! empty( $all_levels_a ) ) {
+		// Find the location of  the level in the array.
+		$key = array_search( $level_id, $all_levels_a );
+
+		// Add level cost text for this level.
+		pmpro_saveCodeCustomLevelCostText( $code_id, $level_id, wp_unslash( $level_cost_text_a[$key] ) );
 	}
 }
-add_action("pmpro_save_discount_code_level", "pclct_pmpro_save_discount_code_level", apply_filters('pclct_pmpro_level_cost_text_priority', 99), 2);
+add_action( 'pmpro_save_discount_code_level', 'pclct_pmpro_save_discount_code_level', apply_filters( 'pclct_pmpro_level_cost_text_priority', 99 ), 2 );
 
 //update level cost text based on the discount code used
 function pclct_pmpro_level_cost_text_code($cost, $level)

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -360,12 +360,12 @@ add_action("pmpro_discount_code_after_level_settings", "pclct_pmpro_discount_cod
 function pclct_pmpro_save_discount_code_level($code_id, $level_id)
 {
 	$all_levels_a = array_map( 'intval', $_REQUEST['all_levels'] );							//array of level ids checked for this code
-	$level_cost_text_a = sanitize_text_field( $_REQUEST['level_cost_text'] );			//level_cost_text for levels checked
-	
+	$level_cost_text_a = array_map( 'wp_kses_post', $_REQUEST['level_cost_text'] );			//level_cost_text for levels checked
+
 	if(!empty($all_levels_a))
 	{
 		$key = array_search($level_id, $all_levels_a);				//which level is it in the list?
-		pmpro_saveCodeCustomLevelCostText($code_id, $level_id, wp_kses_post( wp_unslash( $level_cost_text_a[$key] ) ) );			//add level cost text for this level
+		pmpro_saveCodeCustomLevelCostText($code_id, $level_id, wp_unslash( $level_cost_text_a[$key] ) );			//add level cost text for this level
 	}
 }
 add_action("pmpro_save_discount_code_level", "pclct_pmpro_save_discount_code_level", apply_filters('pclct_pmpro_level_cost_text_priority', 99), 2);

--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Custom Level Cost Text Add On
 Plugin URI: https://www.paidmembershipspro.com/add-ons/pmpro-custom-level-cost-text/
 Description: Modify the default level cost text per level, per discount code, or globally via advanced settings.
-Version: 0.4
+Version: 0.4.1
 Author: Paid Memberships Pro
 Author URI: https://www.paidmembershipspro.com/
 Text Domain: pmpro-level-cost-text

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: strangerstudios
 Tags: paid memberships pro, pmpro, memberships, ecommerce, level cost
 Requires at least: 5.2
 Tested up to: 6.1
-Stable tag: 0.4
+Stable tag: 0.4.1
 
 Modify the default level cost text per level, per discount code, or globally via advanced settings.
 
@@ -23,6 +23,10 @@ This plugin requires Paid Memberships Pro.
 1. Edit a Membership Level, Discount Code or the Memberships > Advanced Settings page to modify generated level cost text.
 
 == Changelog =
+
+= 0.4.1 - 2023-02-14 =
+* BUG FIX: Fixed bug with saving custom level cost text on levels for a Discount Code.
+
 = 0.4 - 2023-01-12 =
 * ENHANCEMENT: Hide the expiration text when Custom Level Cost Text is used for a level. Give full control to the custom text.
 * ENHANCEMENT: General improvements to sanitization and escaping of text fields/values.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Fixing bug where the level cost text on the discount codes were not saving due to incorrect field sanitization.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create a discount code
2. Add level cost text for one or more levels
3. Without the code, you get an error for uninitialized string offset.
4. With this code, the fields properly save. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
* BUG FIX: Fixed issue where level cost text wasn't saving for discount codes.
* 
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.