### PR TITLE
Updating headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -215,7 +215,7 @@ function pclct_pmpro_membership_level_after_other_settings()
 	else
 		$level_cost_text = "";
 	?>
-<h3 class="topborder"><?php esc_html_e("Custom Level Cost Text", "pmpro-level-cost-text"); ?></h3>
+<h2 class="topborder"><?php esc_html_e("Custom Level Cost Text", "pmpro-level-cost-text"); ?></h2>
 <p><?php echo sprintf(__('Override the default level cost using the available placeholders or custom text. Make sure the prices in this text match your settings above. You can modify the format of the default text in %s', 'pmpro-level-cost-text'), '<a href="' . esc_url( admin_url('admin.php?page=pmpro-advancedsettings') ) . '">' . esc_html__('Advanced Settings', 'pmpro-level-cost-text') . '.</a>');?></p>
     <table class="form-table">
         <tbody>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updating all h3 tags to h2 tags