### PR TITLE
BUG FIX: Hide decimals on one-time payments

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -109,7 +109,7 @@ function pclct_format_cost($cost) {
 		
 		$parts = explode( $decimal_separator, $cost );
 		if ( ! empty( $parts[1] ) && strpos( $parts[1], '00' ) !== false ) {
-			$cost = str_replace( array( $decimal_separator . '00 ', $decimal_separator . '00/' ), array( ' ', '/' ) , $cost ); //Support for "per" and "slash" options in the cost text.
+			$cost = str_replace( array( $decimal_separator . '00', $decimal_separator . '00/' ), array( '', '/' ) , $cost ); //Support for "per" and "slash" options in the cost text.
 		}
 	}
 	


### PR DESCRIPTION
* BUG FIX: Fixed an issue where "hide unnecessary decimals" wasn't working for one time payments.

Resolves: #38

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes Issue: XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.