### PR TITLE
Replacing 0.00 with Free for free levels when set in advanced settings

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -89,9 +89,9 @@ function pclct_format_cost($cost) {
 	if(get_option('pmpro_pmpro_use_free') == 'Yes'){
 		global $pmpro_currency_symbol;
 		$cost = str_replace($pmpro_currency_symbol.'0.00', __('Free', "pmpro-level-cost-text"), $cost);
-		$cost = str_replace(' 0.00'.$pmpro_currency_symbol, ' '.__('Free', "pmpro-level-cost-text"), $cost); //Space added to avoid replacing 0.00 in 10.00 etc.
+		$cost = preg_replace('/^0.00/', __('Free', "pmpro-level-cost-text"), $cost);
 		$cost = str_replace($pmpro_currency_symbol.'0,00', __('Free', "pmpro-level-cost-text"), $cost);
-		$cost = str_replace(' 0,00'.$pmpro_currency_symbol, ' '.__('Free', "pmpro-level-cost-text"), $cost); //Space added to avoid replacing 0.00 in 10.00 etc.
+		$cost = preg_replace('/^0,00/', __('Free', "pmpro-level-cost-text"), $cost);
 	}
 	
 	if(get_option('pmpro_pmpro_use_slash') == 'Yes'){


### PR DESCRIPTION
Using preg_replace to replace "0.00" with free when not preceded by a currency symbol and not part of cost eg. 50.00

### All Submissions:

* [x] Have you followed the [Contributing guideline](CONTRIBUTING.MD)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves: #41 

### How to test the changes in this Pull Request:

1. Create a free level.
2. Set the custom cost text to "The price is !!initial_payment!!" and save the level.
3. Under PMPro's Advanced Settings set the option "Replace 0.00 with 'free'" to Yes, save your settings.
4. Navigate to pages with level cost, observe that 0.00 is replaced with 'free'

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes an issue where replacing 0.00 with "Free" wasn't working in some cases.