### PR TITLE
Apply Level Cost Text format settings to [pmpro_membership_level] shortcode fields

### DIFF
--- a/pmpro-level-cost-text.php
+++ b/pmpro-level-cost-text.php
@@ -118,9 +118,38 @@ function pclct_format_cost($cost) {
 		$cost = str_replace("Week", "Wk", $cost);
 		$cost = str_replace("Month", "Mo", $cost);
 	}
-	
+
 	return $cost;
 }
+
+/**
+ * Apply the Level Cost Text format settings to price and period fields output by
+ * the [pmpro_membership_level] shortcode, matching the "level_cost" field.
+ *
+ * @since TBD
+ *
+ * @param string $r     The formatted shortcode field output.
+ * @param object $level The PMPro level object.
+ * @param string $field The field being output.
+ * @return string The formatted shortcode field output.
+ */
+function pclct_pmpro_membership_level_shortcode_field( $r, $level, $field ) {
+	// Fields where pclct formatting is meaningful. Excludes name/description.
+	$formatted_fields = array(
+		'initial_payment',
+		'billing_amount',
+		'trial_amount',
+		'cycle_period',
+		'expiration_period',
+	);
+
+	if ( in_array( $field, $formatted_fields, true ) && '' !== $r ) {
+		$r = pclct_format_cost( $r );
+	}
+
+	return $r;
+}
+add_filter( 'pmpro_membership_level_shortcode_field', 'pclct_pmpro_membership_level_shortcode_field', 10, 3 );
 
 //Switches out variables within '!!' with the intended value
 function pclct_apply_variables( $custom_text, $cost, $level ) {


### PR DESCRIPTION
## Why

The `[pmpro_membership_level]` shortcode's `level_cost` field already respects the Level Cost Text format settings (Hide Decimals, Use "Free", Abbreviate Periods, etc.) because it runs through the `pmpro_level_cost_text` filter. The individual price and period fields — e.g. `[pmpro_membership_level field="billing_amount" level="1"]` — did **not**, so output was inconsistent (`$10.00` vs `$10`, `Month` vs `Mo`).

This was raised with @davidparker, who approved the approach provided the compatibility code lives entirely within this Add On. It does — no PMPro core changes are needed.

## What

Hooks the `pmpro_membership_level_shortcode_field` filter (added in PMPro 3.8) and runs the relevant fields through the existing `pclct_format_cost()`:

- **Price fields** — `initial_payment`, `billing_amount`, `trial_amount` → pick up Hide Decimals / Use "Free".
- **Period fields** — `cycle_period`, `expiration_period` → pick up Abbreviate Periods.
- **`name` / `description` are intentionally excluded** so a level named e.g. "Monthly Plan" isn't mangled to "Moly Plan".
- Zero-value price fields are left empty (PMPro core blanks them before the filter runs), so behavior there is unchanged.

The filter only exists in PMPro 3.8+; on older versions it never fires, so this is a no-op.

## Testing

Verified locally against a `$10/Month` level with PMPro 3.8:

| Field | Setting off | Setting on |
|---|---|---|
| `billing_amount` / `initial_payment` | `$10.00` | `$10` (Hide Decimals) |
| `cycle_period` | `Month` | `Mo` (Abbreviate Periods) |
| `name` | `Premium` | `Premium` (unchanged) |
| `level_cost` | unchanged | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)